### PR TITLE
Update repo for triggers test

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -28,7 +28,7 @@ services:
     service_id: githubpublic
     parameters:
       repo_name: 'Tekton-Github-Triggers-{{timestamp}}'
-      source_repo_url: 'https://github.com/idsb3t1/tekton-two-listener-KEEP'
+      source_repo_url: 'https://github.com/ziheng-c/greenwell-tekton'
       type: clone
       has_issues: false
   build:


### PR DESCRIPTION
Use one of our repos that we have full control over, as part of the toolchain creation for the triggers test